### PR TITLE
Fix off-by-one in prefix argument index

### DIFF
--- a/ace-mc.el
+++ b/ace-mc.el
@@ -140,7 +140,7 @@ When the region is active, prompt for AceJump matches based on matching strings.
     (if (< index 0)
         (setq index 0))
     (if (>= index submode-list-length)
-        (setq index submode-list-length))
+        (setq index (- submode-list-length 1)))
     (setq ace-mc-ace-mode-function (if (use-region-p)
 				     'ace-mc-regexp-mode
 				   (nth index ace-jump-mode-submode-list)))


### PR DESCRIPTION
Just a minor change because an index of length is out of bounds.

Mostly I just wanted to say thanks for making this! I've been waiting for someone to do something like this and this is great. I especially like the way it behaves when region is active. Thanks again!
